### PR TITLE
fix: make image container runnable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
-FROM golang:1.19-alpine
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.20.5-alpine as builder
 WORKDIR /app
 COPY . .
-
 RUN go mod download
-RUN go build -o /app/myapp ./cmd
+RUN go build -o /app/cmd/oras-explorer ./cmd
+
+
+FROM docker.io/library/alpine:3.17.1
+COPY --from=builder /app /app
+WORKDIR /app/cmd
 EXPOSE 3000
-CMD ["/app/myapp"]
+ENTRYPOINT ["/app/cmd/oras-explorer"]


### PR DESCRIPTION
The image built from current Dockerfile will show `failed to render: render: template home does not exist` after being ran, the root cause is that `web` folder is hardcoded to be in the parent folder of working directory. This PR fixes the issue.

Also, the builder image and server image are separated.