### PR TITLE
feat: single input form

### DIFF
--- a/web/artifact.html
+++ b/web/artifact.html
@@ -8,7 +8,7 @@
       <!-- hero form -->
       <div class="hero">
         <div class="form">
-          {{ template "form" }}
+          {{template "inputForm"}}
           <button onclick='onSubmit("artifact")'>
             <div class="icon">
               <img src="./static/images/downArrow.svg" alt="" />

--- a/web/form.html
+++ b/web/form.html
@@ -1,43 +1,25 @@
-{{ define "form" }}
-<div class="artifactInputForm">
-  <div>
-    <div class="form-floating mb-3" id="registry">
-      <input
-        type="text"
-        class="form-control"
-        id="floatingInput"
-        placeholder="library/nginx"
-        onfocus="showRegList()"
-        onclick="showRegList()"
-      />
-      <label for="floatingInput">Registry</label>
-      <div class="registryDropdown hide"></div>
-    </div>
-
-    <div class="form-floating mb-3" id="repository">
-      <input
-        type="text"
-        class="form-control"
-        id="floatingInput"
-        placeholder="repository"
-        oninput="updateRepoList()"
-        onfocus="listRepos()"
-      />
-      <label for="floatingInput">Repository</label>
-      <div class="repoDropdown hide"></div>
-    </div>
-  </div>
-  <div class="form-floating mb-3" id="digestortag">
-    <input
-      type="text"
-      class="form-control"
-      id="floatingInput"
-      placeholder="tag or digest"
-      oninput="updateTagList()"
-      onfocus="listTags()"
-    />
-    <label for="floatingInput">Tag or Digest</label>
-    <div class="tagListDropdown hide"></div>
-  </div>
+{{ define "inputForm" }}
+<div class="inputs">
+  <input
+    type="text"
+    class="i1"
+    placeholder="registry"
+    onclick="showRegList()"
+  />
+  <span>/</span>
+  <input
+    type="text"
+    class="i2"
+    placeholder="repository"
+    oninput="updateRepoList()"
+  />
+  <span class="tagSpan">/</span>
+  <input
+    type="text"
+    class="i3"
+    placeholder="tag or digest"
+    oninput="updateTagList()"
+  />
+  <div class="dropdown"><div></div></div>
 </div>
 {{ end }}

--- a/web/form.html
+++ b/web/form.html
@@ -13,7 +13,7 @@
     placeholder="repository"
     oninput="updateRepoList()"
   />
-  <span class="tagSpan">/</span>
+  <span class="tagSpan"></span>
   <input
     type="text"
     class="i3"

--- a/web/home.html
+++ b/web/home.html
@@ -16,7 +16,7 @@
         </div>
       </div>
       <div class="form">
-        {{ template "form" }}
+        {{ template "inputForm" }}
         <button onclick='onSubmit("home")'>
           Explore now <img src="./static/images/rightArrow.svg" alt="" />
         </button>

--- a/web/static/css/artifact_page.css
+++ b/web/static/css/artifact_page.css
@@ -500,7 +500,7 @@ td, tr, th {
 .dropdown {
   position: absolute;
   width: 400px;
-  height: 245px;
+  height: 250px;
   display: none;
   top: 125%;
   background-color: white;

--- a/web/static/css/artifact_page.css
+++ b/web/static/css/artifact_page.css
@@ -10,7 +10,7 @@
   margin: auto;
 }
 .form {
-  width: 50vw;
+  width: 60vw;
   max-width: 1400px;
   background-color: #fff;
   margin: auto;
@@ -27,21 +27,18 @@
   background-color: var(--text-light);
 }
 .dropdown .error,
-.dropdown .info,
-.repoDropdown .error,
-.repoDropdown .info {
+.dropdown .info {
   display: flex;
   justify-content: center;
   align-items: center;
   width: 100%;
   gap: 1rem;
   margin: auto;
+  height: 100%;
   flex-direction: column;
 }
 .dropdown .error img,
-.dropdown .info img,
-.repoDropdown .error img,
-.repoDropdown .info img {
+.dropdown .info img {
   width: 32px;
 }
 .registryDropdown .items.active {
@@ -467,7 +464,7 @@ td, tr, th {
   position: relative;
   border: none;
   padding: 5px;
-  color: #757575;
+  color: var(--secondary-color);
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   font-weight: 600;
@@ -480,25 +477,23 @@ td, tr, th {
   line-height: 0 !important;
 }
 
+.inputs input::placeholder {
+  color: #757575;
+}
+
 .i1 {
   width: 75px;
-}
-
-.i2 {
-  width: 95px;
-}
-
-.i1 {
   max-width: 30%;
 }
 
 .i2 {
-  max-width: 40%;
+  width: 95px;
+  max-width: 50%;
 }
 
 .i3 {
-  flex: 1;
   min-width: 20%;
+  flex: 1;
   max-width: none;
 }
 
@@ -533,8 +528,12 @@ td, tr, th {
   cursor: pointer;
 }
 
+.dropdown .dropdown-item.active {
+  background-color: var(--text-light);
+}
+
 .dropdown .items:hover,
-.dropdown > div p:hover {
+.dropdown > div > p:hover {
   background-color: var(--secondary-color-light);
 }
 
@@ -544,12 +543,13 @@ td, tr, th {
 
 .dropdown > div > p {
   width: 100%;
-  word-wrap: break-word;
   padding: 8px 15px;
   font-weight: 500;
   cursor: pointer;
   margin: 0;
   border-bottom: 1px solid var(--secondary-color-light);
+  white-space: normal;
+  word-wrap: break-word;
 }
 
 .dropdown > div::-webkit-scrollbar {
@@ -568,6 +568,10 @@ td, tr, th {
 .dropdown > div::-webkit-scrollbar-track {
   background-color: #f1f1f1;
   border-radius: 4px;
+}
+
+.dropdown > div .skeletonLoader {
+  height: 60px;
 }
 
 .dropdown::after {

--- a/web/static/css/artifact_page.css
+++ b/web/static/css/artifact_page.css
@@ -10,7 +10,7 @@
   margin: auto;
 }
 .form {
-  width: 60vw;
+  width: 50vw;
   max-width: 1400px;
   background-color: #fff;
   margin: auto;
@@ -18,74 +18,16 @@
   border-radius: 10px;
   box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
 }
-.artifactInputForm {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  font-size: var(--p-size);
-  justify-content: center;
-}
-.artifactInputForm > div {
-  display: flex;
-  width: 100%;
-  gap: 2rem;
-}
-.artifactInputForm .ui.default.dropdown:not(.button) > .text,
-.ui.dropdown:not(.button) > .default.text {
-  color: var(--secondary-color-light);
-}
-.artifactInputForm #digestortag {
-  position: relative;
-}
-.artifactInputForm #registry,
-.artifactInputForm #repository {
-  position: relative;
-  width: 100%;
-}
-.tagListDropdown,
-.registryDropdown,
-.repoDropdown {
-  position: absolute;
-  top: 70px;
-  border-radius: 10px;
-  width: 100%;
-  z-index: 10;
-  background: #ffff;
-  box-shadow: 2px 7px 10px 0px rgba(0, 0, 0, 0.31);
-  flex-direction: column;
-  overflow: auto;
-}
-.registryDropdown {
-  height: fit-content;
-}
-.tagListDropdown,
-.repoDropdown {
-  height: 165px;
-}
-.tagListDropdown .items,
-.repoDropdown .items {
-  cursor: pointer;
-  padding: 8px 15px;
-}
-.tagListDropdown .items.active,
+.dropdown .items.active,
 .repoDropdown .items.active {
   background-color: var(--text-light);
 }
-.tagListDropdown p,
-.repoDropdown p {
-  padding: 5px 15px;
-  cursor: pointer;
-}
-.tagListDropdown p:hover,
-.repoDropdown p:hover {
-  background-color: var(--text-light);
-}
 .repoDropdown .repoListItem.active,
-.tagListDropdown .tagListItem.active {
+.dropdown .tagListItem.active {
   background-color: var(--text-light);
 }
-.tagListDropdown .error,
-.tagListDropdown .info,
+.dropdown .error,
+.dropdown .info,
 .repoDropdown .error,
 .repoDropdown .info {
   display: flex;
@@ -96,37 +38,14 @@
   margin: auto;
   flex-direction: column;
 }
-.tagListDropdown .error img,
-.tagListDropdown .info img,
+.dropdown .error img,
+.dropdown .info img,
 .repoDropdown .error img,
 .repoDropdown .info img {
   width: 32px;
 }
-.registryDropdown .items {
-  cursor: pointer;
-  padding: 8px 15px;
-  display: flex;
-  gap: 15px;
-  align-items: center;
-}
 .registryDropdown .items.active {
   background-color: var(--text-light);
-}
-.registryDropdown .items img {
-  width: 20px;
-}
-.registryDropdown .items:hover {
-  background-color: var(--text-light);
-}
-.artifactInputForm .form-control {
-  font-size: medium;
-}
-.artifactInputForm .form-floating > label {
-  font-size: var(--p-size);
-}
-.artifactInputForm .ui.dropdown > .text {
-  display: flex;
-  align-items: center;
 }
 .form button {
   background-color: var(--secondary-color);
@@ -141,7 +60,7 @@
 .hero button img {
   width: 30px;
 }
-.tagListDropdown .skeletonLoader,
+.dropdown .skeletonLoader,
 .registryDropdown .skeletonLoader {
   width: 95%;
   transform: translateX(10px);
@@ -531,4 +450,164 @@ td, tr, th {
 }
 .metaData1 .registry img {
   width: 30px;
+}
+
+/* single input form styles */
+.inputs {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: 1px solid gray;
+  padding: 10px 5px;
+  border-radius: 10px;
+}
+
+.inputs input {
+  position: relative;
+  border: none;
+  padding: 5px;
+  color: #757575;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+  font-weight: 600;
+  letter-spacing: 1px;
+  outline: none;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  min-width: 0 !important;
+  line-height: 0 !important;
+}
+
+.i1 {
+  width: 75px;
+}
+
+.i2 {
+  width: 95px;
+}
+
+.i1 {
+  max-width: 30%;
+}
+
+.i2 {
+  max-width: 40%;
+}
+
+.i3 {
+  flex: 1;
+  min-width: 20%;
+  max-width: none;
+}
+
+.dropdown {
+  position: absolute;
+  width: 400px;
+  height: 245px;
+  display: none;
+  top: 125%;
+  background-color: white;
+  border: 1px solid var(--secondary-color-light);
+  border-radius: 10px;
+  box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.25);
+}
+
+.dropdown > div {
+  width: 100%;
+  height: 100%;
+  padding: 10px 0px;
+  overflow: auto;
+}
+
+.dropdown .items {
+  border-bottom: 1px solid var(--secondary-color-light);
+  overflow: auto;
+  padding: 10px 20px;
+  overflow-x: hidden;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.dropdown .items:hover,
+.dropdown > div p:hover {
+  background-color: var(--secondary-color-light);
+}
+
+.dropdown img {
+  width: 25px;
+}
+
+.dropdown > div > p {
+  width: 100%;
+  word-wrap: break-word;
+  padding: 8px 15px;
+  font-weight: 500;
+  cursor: pointer;
+  margin: 0;
+  border-bottom: 1px solid var(--secondary-color-light);
+}
+
+.dropdown > div::-webkit-scrollbar {
+  width: 8px;
+}
+
+.dropdown > div::-webkit-scrollbar-thumb {
+  background-color: #aaa;
+  border-radius: 4px;
+}
+
+.dropdown > div::-webkit-scrollbar-thumb:hover {
+  background-color: #888;
+}
+
+.dropdown > div::-webkit-scrollbar-track {
+  background-color: #f1f1f1;
+  border-radius: 4px;
+}
+
+.dropdown::after {
+  position: absolute;
+  top: -18px;
+  left: 10.3%;
+  display: block;
+  content: "";
+  width: 0px;
+  height: 0px;
+  border-width: 10px;
+  border-style: solid;
+  border-color: transparent transparent white transparent;
+}
+
+.dropdown::before {
+  position: absolute;
+  top: -21px;
+  left: 10.3%;
+  display: block;
+  content: "";
+  width: 0px;
+  height: 0px;
+  border-width: 11px;
+  border-style: solid;
+  border-color: transparent transparent var(--secondary-color-light) transparent;
+}
+
+.show-dropdown .dropdown {
+  display: block;
+  animation: slideDown 0.3s ease-out forwards;
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }

--- a/web/static/css/home_page.css
+++ b/web/static/css/home_page.css
@@ -30,7 +30,7 @@
   margin-top: -5px;
 }
 .form {
-  width: 60vw;
+  width: 50vw;
   max-width: 1400px;
   transform: translateY(-40%);
   background-color: #fff;
@@ -258,7 +258,7 @@
 .dropdown {
   position: absolute;
   width: 400px;
-  height: 245px;
+  height: 250px;
   display: none;
   top: 125%;
   background-color: white;

--- a/web/static/css/home_page.css
+++ b/web/static/css/home_page.css
@@ -63,91 +63,6 @@
   position: relative;
   width: 100%;
 }
-.tagListDropdown,
-.registryDropdown,
-.repoDropdown {
-  position: absolute;
-  top: 70px;
-  border-radius: 10px;
-  width: 100%;
-  z-index: 10;
-  background: #ffff;
-  box-shadow: 2px 7px 10px 0px rgba(0, 0, 0, 0.31);
-  flex-direction: column;
-  overflow: auto;
-}
-.registryDropdown {
-  height: fit-content;
-}
-.tagListDropdown,
-.repoDropdown {
-  height: 165px;
-}
-.repoDropdown .repoListItem.active, .tagListDropdown .tagListItem.active {
-  background-color: var(--text-light);
-}
-.registryDropdown .items.active {
-  background-color: var(--text-light);
-}
-.tagListDropdown .items.active,
-.repoDropdown .items.active {
-  background-color: var(--text-light);
-}
-.tagListDropdown .items,
-.repoDropdown .items {
-  cursor: pointer;
-  padding: 8px 15px;
-}
-.tagListDropdown p,
-.repoDropdown p {
-  padding: 5px 15px;
-  cursor: pointer;
-}
-.tagListDropdown p:hover,
-.repoDropdown p:hover {
-  background-color: var(--text-light);
-}
-.tagListDropdown .error,
-.tagListDropdown .info,
-.repoDropdown .error,
-.repoDropdown .info {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 100%;
-  gap: 1rem;
-  margin: auto;
-  flex-direction: column;
-}
-.tagListDropdown .error img,
-.tagListDropdown .info img,
-.repoDropdown .error img,
-.repoDropdown .info img {
-  width: 32px;
-}
-.registryDropdown .items {
-  cursor: pointer;
-  padding: 8px 15px;
-  display: flex;
-  gap: 15px;
-  align-items: center;
-}
-.registryDropdown .items img {
-  width: 20px;
-}
-.registryDropdown .items:hover {
-  background-color: var(--text-light);
-}
-.artifactInputForm .form-control {
-  font-size: medium;
-}
-.artifactInputForm .form-floating > label {
-  font-size: var(--p-size);
-}
-.artifactInputForm .ui.dropdown > .text {
-  display: flex;
-  align-items: center;
-}
 .form button {
   background-color: var(--secondary-color);
   padding: 10px 20px;
@@ -160,20 +75,6 @@
 }
 .hero button img {
   width: 30px;
-}
-.tagListDropdown .skeletonLoader,
-.registryDropdown .skeletonLoader {
-  width: 95%;
-  transform: translateX(10px);
-  margin: 10px 0px;
-  height: 50px;
-}
-.form-floating > .form-control-plaintext:focus,
-.form-floating > .form-control-plaintext:not(:placeholder-shown),
-.form-floating > .form-control:focus,
-.form-floating > .form-control:not(:placeholder-shown) {
-  padding-top: 2rem;
-  padding-bottom: 0.625rem;
 }
 /* main body */
 .main {
@@ -217,40 +118,40 @@
 }
 /* main body */
 .features .cards {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    gap: 1rem;
-    width: 90%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  width: 90%;
 }
 .cardItem {
-    width: 100%;
-    border-radius: 30px;
-    border: 3px solid #E6E6E6;
-    background: #FFF;
-    padding: 20px;
-    text-align: left;
+  width: 100%;
+  border-radius: 30px;
+  border: 3px solid #e6e6e6;
+  background: #fff;
+  padding: 20px;
+  text-align: left;
 }
 .cardItem img {
-    width: 40px;
+  width: 40px;
 }
 .cardItem .icon {
-    padding: 15px;
-    border: 3px solid #E6E6E6;
-    background: #FFF;
-    border-radius: 30%;
-    /* display: flex; */
-    width: fit-content;
+  padding: 15px;
+  border: 3px solid #e6e6e6;
+  background: #fff;
+  border-radius: 30%;
+  /* display: flex; */
+  width: fit-content;
 }
-.cardItem h3{
-    font-size: var(--h3-size);
-    font-weight: 600;
-    margin-top: 10px;
+.cardItem h3 {
+  font-size: var(--h3-size);
+  font-weight: 600;
+  margin-top: 10px;
 }
 .cardItem p {
-    font-size: var(--p-size);
-    margin-top: 40px;
-    color: var(--secondary-color);
+  font-size: var(--p-size);
+  margin-top: 40px;
+  color: var(--secondary-color);
 }
 .community {
   display: flex;
@@ -265,43 +166,202 @@
   font-size: var(--h2-size);
 }
 .community .connectOptions {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 3rem;
-    margin: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 3rem;
+  margin: 2rem;
 }
 .community .urls {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 1rem;
-    justify-content: space-between;
-    font-size: var(--p-size);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  justify-content: space-between;
+  font-size: var(--p-size);
 }
 .community .urlItems {
-    display: flex;
-    gap: 10px;
-    box-shadow: 0px 4px 8px 0px rgba(0, 0, 0, 0.10);
-    align-items: center;
-    padding: 10px 20px;
-    border-radius: 10px;
+  display: flex;
+  gap: 10px;
+  box-shadow: 0px 4px 8px 0px rgba(0, 0, 0, 0.1);
+  align-items: center;
+  padding: 10px 20px;
+  border-radius: 10px;
 }
 .community .urlItems img {
-    width: 25px;
+  width: 25px;
 }
 .urlItems p {
-    font-weight: 700;
+  font-weight: 700;
 }
 .community .calendarBlock {
-    background: var(--primary-gradient);
-    color: #fff;
-    padding: 20px;
-    border-radius: 20px;
+  background: var(--primary-gradient);
+  color: #fff;
+  padding: 20px;
+  border-radius: 20px;
 }
 .calendarBlock button {
-    margin: auto;
-    color: var(--primary-color);
-    padding: 10px 20px;
-    margin-top: 3rem;
+  margin: auto;
+  color: var(--primary-color);
+  padding: 10px 20px;
+  margin-top: 3rem;
+}
+/* single input form styles */
+.inputs {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: 1px solid gray;
+  padding: 10px 5px;
+  border-radius: 10px;
+}
+
+.inputs input {
+  position: relative;
+  border: none;
+  padding: 5px;
+  color: #757575;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+  font-weight: 600;
+  letter-spacing: 1px;
+  outline: none;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  min-width: 0 !important;
+  line-height: 0 !important;
+}
+
+.i1 {
+  width: 75px;
+}
+
+.i2 {
+  width: 95px;
+}
+
+.i1 {
+  max-width: 30%;
+}
+
+.i2 {
+  max-width: 40%;
+}
+
+.i3 {
+  flex: 1;
+  min-width: 20%;
+  max-width: none;
+}
+
+.dropdown {
+  position: absolute;
+  width: 400px;
+  height: 245px;
+  display: none;
+  top: 125%;
+  background-color: white;
+  border: 1px solid var(--secondary-color-light);
+  border-radius: 10px;
+  box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.25);
+}
+
+.dropdown > div {
+  width: 100%;
+  height: 100%;
+  padding: 10px 0px;
+  overflow: auto;
+}
+
+.dropdown .items {
+  border-bottom: 1px solid var(--secondary-color-light);
+  overflow: auto;
+  padding: 10px 20px;
+  overflow-x: hidden;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.dropdown .items:hover,
+.dropdown > div p:hover {
+  background-color: var(--secondary-color-light);
+}
+
+.dropdown img {
+  width: 25px;
+}
+
+.dropdown > div > p {
+  width: 100%;
+  word-wrap: break-word;
+  padding: 8px 15px;
+  font-weight: 500;
+  cursor: pointer;
+  margin: 0;
+  border-bottom: 1px solid var(--secondary-color-light);
+}
+
+.dropdown > div::-webkit-scrollbar {
+  width: 8px;
+}
+
+.dropdown > div::-webkit-scrollbar-thumb {
+  background-color: #aaa;
+  border-radius: 4px;
+}
+
+.dropdown > div::-webkit-scrollbar-thumb:hover {
+  background-color: #888;
+}
+
+.dropdown > div::-webkit-scrollbar-track {
+  background-color: #f1f1f1;
+  border-radius: 4px;
+}
+
+.dropdown::after {
+  position: absolute;
+  top: -18px;
+  left: 10.3%;
+  display: block;
+  content: "";
+  width: 0px;
+  height: 0px;
+  border-width: 10px;
+  border-style: solid;
+  border-color: transparent transparent white transparent;
+}
+
+.dropdown::before {
+  position: absolute;
+  top: -21px;
+  left: 10.3%;
+  display: block;
+  content: "";
+  width: 0px;
+  height: 0px;
+  border-width: 11px;
+  border-style: solid;
+  border-color: transparent transparent var(--secondary-color-light) transparent;
+}
+
+.show-dropdown .dropdown {
+  display: block;
+  animation: slideDown 0.3s ease-out forwards;
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }

--- a/web/static/css/home_page.css
+++ b/web/static/css/home_page.css
@@ -206,6 +206,7 @@
   padding: 10px 20px;
   margin-top: 3rem;
 }
+
 /* single input form styles */
 .inputs {
   position: relative;
@@ -221,7 +222,7 @@
   position: relative;
   border: none;
   padding: 5px;
-  color: #757575;
+  color: var(--secondary-color);
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   font-weight: 600;
@@ -234,25 +235,23 @@
   line-height: 0 !important;
 }
 
+.inputs input::placeholder {
+  color: #757575;
+}
+
 .i1 {
   width: 75px;
-}
-
-.i2 {
-  width: 95px;
-}
-
-.i1 {
   max-width: 30%;
 }
 
 .i2 {
-  max-width: 40%;
+  width: 95px;
+  max-width: 50%;
 }
 
 .i3 {
-  flex: 1;
   min-width: 20%;
+  flex: 1;
   max-width: none;
 }
 
@@ -287,8 +286,12 @@
   cursor: pointer;
 }
 
+.dropdown .dropdown-item.active {
+  background-color: var(--text-light);
+}
+
 .dropdown .items:hover,
-.dropdown > div p:hover {
+.dropdown > div > p:hover {
   background-color: var(--secondary-color-light);
 }
 
@@ -298,12 +301,13 @@
 
 .dropdown > div > p {
   width: 100%;
-  word-wrap: break-word;
   padding: 8px 15px;
   font-weight: 500;
   cursor: pointer;
   margin: 0;
   border-bottom: 1px solid var(--secondary-color-light);
+  white-space: normal;
+  word-wrap: break-word;
 }
 
 .dropdown > div::-webkit-scrollbar {
@@ -322,6 +326,13 @@
 .dropdown > div::-webkit-scrollbar-track {
   background-color: #f1f1f1;
   border-radius: 4px;
+}
+
+.dropdown > div .skeletonLoader {
+  height: 60px;
+  width: 95%;
+  transform: translateX(10px);
+  margin: 10px 0px;
 }
 
 .dropdown::after {
@@ -364,4 +375,20 @@
     opacity: 1;
     transform: translateY(0);
   }
+}
+
+.dropdown .error,
+.dropdown .info {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  gap: 1rem;
+  margin: auto;
+  height: 100%;
+  flex-direction: column;
+}
+.dropdown .error img,
+.dropdown .info img {
+  width: 32px;
 }

--- a/web/static/js/index.js
+++ b/web/static/js/index.js
@@ -337,6 +337,16 @@ repo.addEventListener("change", () => {
 reg.addEventListener("change", () => {
   isRepoRegChanged = true;
 });
+tag.addEventListener("change", () => {
+  if(!tag.value) changeDelimiter("");
+})
+tag.addEventListener("input", () => {
+  if(tag.value.includes("sha256:")) {
+    changeDelimiter("@");
+  } else {
+    changeDelimiter(":");
+  }
+})
 // ends
 
 // copyText

--- a/web/static/js/index.js
+++ b/web/static/js/index.js
@@ -871,7 +871,6 @@ const span2 = document.querySelector(".tagSpan");
 
 function updateDropdownPosition(input) {
   currentActiveInput = input;
-  console.log(input)
   resetItemIndex();
   if (
     (input.classList.contains("i2") && reg.value !== "mcr.microsoft.com") ||
@@ -899,7 +898,7 @@ function resizeInputs() {
   });
 }
 inputs.forEach((input, index) => {
-  input.addEventListener("paste", function handlePastedString(event, id) {
+  input.addEventListener("paste", function handlePastedString(event) {
     const pastedText = event.clipboardData.getData("text/plain");
     const regex = /^(.+?)\/(.+?)(?::([^@]+))?(@(.+))?$/;
     const matches = pastedText.match(regex);
@@ -921,15 +920,17 @@ inputs.forEach((input, index) => {
       inputs[1].value = repository;
       inputs[2].value = tagOrDigest;
     } else {
-      if (id === "1") inputs[0].value = pastedText;
-      else if (id === "2") inputs[1].value = pastedText;
+      if (currentActiveInput.classList.contains("i1")) inputs[0].value = pastedText;
+      else if (currentActiveInput.classList.contains("i2")) inputs[1].value = pastedText;
       else inputs[2].value = pastedText;
     }
     resizeInputs();
+    hideDropdown();
     event.preventDefault();
   });
 
   input.addEventListener("focus", function (event) {
+    currentActiveInput = event.target;
     if (event.target.classList.contains("i1")) {
       showRegList();
     } else if (event.target.classList.contains("i2")) {


### PR DESCRIPTION
this pr:
- adds new single input ui to both home and artifact page
- removes the previous code of 3 input UI
- fixes input related issues #12, #17, #23, #24, #25

### notable features:
- combination of three individual inputs for registry, repository and tag or digest, but feels like single input box
- animated dropdown movement
- copy-paste reference support
- input values auto changes as per page URL for artifact page
- dropdown supports keyboard up-down keys accessibility 
- "Tab" key to move across inputs
- delimiter between 2nd and 3rd inputs `/` changes as if `:` or `@` is pressed
- skeleton loaders
- more

<img width="500" alt="image" src="https://github.com/VasuDevrani/artifact-explorer-oras/assets/101383635/6a5cbb52-485d-4a71-a281-572834749cff">
