### PR TITLE
refactor: fetch referrers concurrently

### DIFF
--- a/pck/handler.go
+++ b/pck/handler.go
@@ -75,7 +75,7 @@ func Referrers() fiber.Handler {
 			return c.Status(errResponse.StatusCode).JSON(errResponse)
 		}
 
-		referrers, err := GenerateReferrerTree(repo, a.Name, artifact)
+		referrers, err := GenerateReferrerTreeConcurrent(repo, a.Name, artifact)
 
 		if err != nil {
 			errResponse := Err("Failed to fetch referrers", fiber.StatusNotFound)

--- a/pck/router.go
+++ b/pck/router.go
@@ -2,45 +2,45 @@ package server
 
 import (
 	"fmt"
-	
 	"github.com/gofiber/fiber/v2"
 )
 
 func AppRouter(app fiber.Router) {
-	app.Get("/", func(c *fiber.Ctx) error {
-		return c.Render("home", nil)
-	})
-
-	app.Get("/artifact", func(c *fiber.Ctx) error {
-		return c.Render("artifact", nil)
-	})
-
-	app.Get("/blob", func(c *fiber.Ctx) error {
-		return c.Render("blob", nil)
-	})
-
-	app.Get("/redirect", func(c *fiber.Ctx) error {
-		image := c.Queries()["image"]
-		mediaType := c.Queries()["mediatype"]
-
-		if isManifest(mediaType, image) {
-			return c.Redirect(fmt.Sprintf("/artifact?image=%s", image))
-		} else {
-			return c.Redirect(fmt.Sprintf("/blob?layer=%s", image))
-		}
-	})
-
+	app.Get("/", homeHandler)
+	app.Get("/artifact", artifactHandler)
+	app.Get("/blob", blobHandler)
+	app.Get("/redirect", redirectHandler)
 	app.Get("/api/tags", Tags())
-
 	app.Get("/api/blob", BlobContent())
-
 	app.Get("/api/referrers", Referrers())
-
 	app.Get("/api/artifact", Manifest())
-
 	app.Get("/api/repos", Repos())
+	app.Get("*", notFoundHandler)
+}
 
-	app.Get("*", func(c *fiber.Ctx) error {
-		return c.Render("404", nil)
-	})
+func homeHandler(c *fiber.Ctx) error {
+	return c.Render("home", nil)
+}
+
+func artifactHandler(c *fiber.Ctx) error {
+	return c.Render("artifact", nil)
+}
+
+func blobHandler(c *fiber.Ctx) error {
+	return c.Render("blob", nil)
+}
+
+func redirectHandler(c *fiber.Ctx) error {
+	image := c.Query("image")
+	mediaType := c.Query("mediatype")
+
+	if isManifest(mediaType, image) {
+		return c.Redirect(fmt.Sprintf("/artifact?image=%s", image))
+	} else {
+		return c.Redirect(fmt.Sprintf("/blob?layer=%s", image))
+	}
+}
+
+func notFoundHandler(c *fiber.Ctx) error {
+	return c.Render("404", nil)
 }

--- a/pck/server.go
+++ b/pck/server.go
@@ -7,37 +7,37 @@ import (
 )
 
 type Server struct {
-	port string
-	staticPath string
+	port         string
+	staticPath   string
 	templatePath string
-	
-	app *fiber.App
-	htmlEngine *html.Engine
+	app          *fiber.App
 }
 
-func Init(port string, staticPath string, templatePath string) Server{
-	var s Server
+func Init(port, staticPath, templatePath string) *Server {
 	engine := html.New(staticPath, templatePath)
-
 	app := fiber.New(fiber.Config{
-        Views: engine,
-    })
+		Views: engine,
+	})
 
 	app.Static("/static", "../web/static")
 
-	s.port = port
-	s.staticPath = staticPath
-	s.templatePath = templatePath
-	s.app = app
+	app.Use(cors.New())
+
+	s := &Server{
+		port:         port,
+		staticPath:   staticPath,
+		templatePath: templatePath,
+		app:          app,
+	}
+	s.configureRoutes()
 
 	return s
 }
 
-func (s *Server) Run() error{
-	app := s.app
-	app.Use(cors.New())
+func (s *Server) Run() error {
+	return s.app.Listen(":" + s.port)
+}
 
-	AppRouter(app)
-
-    return app.Listen(":3000")
+func (s *Server) configureRoutes() {
+	AppRouter(s.app)
 }

--- a/pck/utils.go
+++ b/pck/utils.go
@@ -112,8 +112,8 @@ func GenerateReferrerTreeConcurrent(repo *remote.Repository, name string, artifa
 				}
 
 				mu.Lock()
+				defer mu.Unlock()
 				result = append(result, res)
-				mu.Unlock()
 			}(referrer)
 		}
 		return nil

--- a/pck/utils.go
+++ b/pck/utils.go
@@ -105,6 +105,7 @@ func GenerateReferrerTreeConcurrent(repo *remote.Repository, name string, artifa
 			go func(ref v1.Descriptor) {
 				defer wg.Done()
 
+				// FIXME: handle error
 				nodes, _ := GenerateReferrerTreeConcurrent(repo, artifact+ATSYMBOL+string(ref.Digest), artifact)
 				res := Referrer{
 					Ref:   ref,

--- a/pck/utils.go
+++ b/pck/utils.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"sync"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/opencontainers/go-digest"
@@ -86,31 +87,42 @@ func ArtifactFromQuery(q Query) Artifact {
 	return a
 }
 
-func GenerateReferrerTree(repo *remote.Repository, name string, artifact string) ([]Referrer, error) {
+func GenerateReferrerTreeConcurrent(repo *remote.Repository, name string, artifact string) ([]Referrer, error) {
 	ctx := context.Background()
 
 	descriptor, err := oras.Resolve(ctx, repo, name, oras.DefaultResolveOptions)
-
 	if err != nil {
 		return nil, err
 	}
 
+	var wg sync.WaitGroup
+	var mu sync.Mutex
 	result := []Referrer{}
+
 	if err := repo.Referrers(ctx, descriptor, "", func(referrers []v1.Descriptor) error {
 		for _, referrer := range referrers {
-			nodes, _ := GenerateReferrerTree(repo, artifact+ATSYMBOL+string(referrer.Digest), artifact)
-			res := Referrer{
-				Ref:   referrer,
-				Nodes: nodes,
-			}
+			wg.Add(1)
+			go func(ref v1.Descriptor) {
+				defer wg.Done()
 
-			result = append(result, res)
+				nodes, _ := GenerateReferrerTreeConcurrent(repo, artifact+ATSYMBOL+string(ref.Digest), artifact)
+				res := Referrer{
+					Ref:   ref,
+					Nodes: nodes,
+				}
+
+				mu.Lock()
+				result = append(result, res)
+				mu.Unlock()
+			}(referrer)
 		}
 		return nil
 	}); err != nil {
 		return nil, err
 	}
-	return result, err
+
+	wg.Wait()
+	return result, nil
 }
 
 func Err(errorMessage string, statusCode int) ErrorResponse {


### PR DESCRIPTION
- cleaner and more readable code
- parallel execution code for fetching referrers (goroutines)
- minimized unnecessary error checks